### PR TITLE
refs #352 deprecated camel-case function names and implemented functi…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ set(QMOD
     qlib/YamlRpcClient.qm
 )
 
-qore_wrap_qpp(QPP_SOURCES ${QPP_SRC})
+qore_wrap_qpp_value(QPP_SOURCES ${QPP_SRC})
 
 SET (module_name "yaml")
 

--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -15,6 +15,11 @@ version 0.5
   current time zone locale so that time zone rules can be applied to
   deserialized dates, otherwise time zone information is always lost which can
   cause errors when performing date arithmetic on deserialized yaml dates
+* deprecated camel-case function names in favor of names conforming to the
+  standard naming convention for functions:
+  - makeYAML() deprecated for make_yaml()
+  - parseYAML() deprecated for parse_yaml()
+  - getYAMLInfo() deprecated for get_yaml_info()
 
 
 ***********

--- a/docs/mainpage.doxygen.tmpl
+++ b/docs/mainpage.doxygen.tmpl
@@ -2,13 +2,6 @@
 
     @tableofcontents
 
-    Contents of this documentation:
-    - @ref yamlintro
-    - @ref functions
-    - @ref qore_to_yaml_type_mappings
-    - @ref yaml_emitter_option_constants
-    - @ref yamlreleasenotes
-
     @section yamlintro Introduction
 
     The yaml module provides <a href="http://www.yaml.org">YAML</a> functionality to Qore, allowing qore programs to read and write information in %YAML syntax.
@@ -35,28 +28,37 @@ This module is released under a choice of two licenses:
     - <a href="../../YamlRpcHandler/html/index.html">YamlRpcHandler user module</a>
 
     @section Examples
-    
+
     @par To serialize a simple value or a complex data structure to a YAML string:
     @code
 %requires yaml
-my string $yaml_str = makeYAML($data, YAML::Canonical);
+my string $yaml_str = make_yaml($data, YAML::Canonical);
     @endcode
 
     @par To deserialize a YAML string to a Qore value:
     @code
 %requires yaml
-my any $data = parseYAML($yaml_str);
+my any $data = parse_yaml($yaml_str);
     @endcode
 
-    @section functions Available Functions
-    
+    @section yaml_functions Available Functions
+
     |!Function|!Description|
-    |@ref makeYAML()|creates a %YAML string from Qore data|
-    |@ref parseYAML()|parses a %YAML string and returns Qore data|
-    |@ref getYAMLInfo()|returns version information about <a href="http://pyyaml.org/wiki/LibYAML">libyaml</a>|
+    |@ref make_yaml()|creates a %YAML string from Qore data|
+    |@ref parse_yaml()|parses a %YAML string and returns Qore data|
+    |@ref get_yaml_info()|returns version information about <a href="http://pyyaml.org/wiki/LibYAML">libyaml</a>|
+
+    @section yaml_deprecated_functions Deprecated Functions
+
+    The following camel-case functions were deprecated in yaml 0.5:
+
+    |!Deprecated Function|!New Function|
+    |@ref makeYAML()|@ref make_yaml()|
+    |@ref parseYAML()|@ref parse_yaml()|
+    |@ref getYAMLInfo()|@ref get_yaml_info()|
 
     @section qore_to_yaml_type_mappings Qore to YAML Type Mappings
-    
+
     Note that all Qore types except objects can be serialized to YAML,
     however \c NULL will be deserialized as \c NOTHING.
 
@@ -84,6 +86,8 @@ my any $data = parseYAML($yaml_str);
       - <a href="../../DataStreamUtil/html/index.html">DataStreamUtil user module</a>
     - user modules moved to top-level qore module directory from version-specific module directory since they are valid for multiple versions of qore
     - date/time values (yaml !!timestamp type) are now always returned in the current time zone locale so that time zone rules can be applied to deserialized dates; previously time zone information was always lost which could cause errors when performing date arithmetic on deserialized yaml dates
+    - fixed bugs deserializing canonically-encoded YAML strings; arbitrary-precision numeric values were deserialized with their precision values ignored and floating point +/-inf were deserialized as zero
+    - deprecated old camel-case names and implemented new function names confirming to the standard naming convention for functions
 
     @subsection yaml04 yaml Module Version 0.4
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 MNAME=yaml
 
 ql_yaml.cpp: ql_yaml.qpp
-	qpp $<
+	qpp -V $<
 
 GENERATED_SOURCES = ql_yaml.cpp
 CLEANFILES = $(GENERATED_SOURCES)

--- a/src/ql_yaml.qpp
+++ b/src/ql_yaml.qpp
@@ -23,6 +23,35 @@
 
 #include "yaml-module.h"
 
+static QoreStringNode* q_make_yaml(QoreValue data, int64 flags, int64 width, int64 indent, ExceptionSink* xsink) {
+   QoreYamlStringWriteHandler str;
+   {
+      QoreYamlEmitter emitter(str, flags, width, indent, xsink);
+      if (*xsink)
+	 return 0;
+
+      if (emitter.emit(data))
+	 return 0;
+   }
+
+   return str.take();
+}
+
+static QoreHashNode* q_get_yaml_info() {
+   QoreHashNode *h = new QoreHashNode;
+
+   h->setKeyValue("version", new QoreStringNode(yaml_get_version_string()), 0);
+
+   int major, minor, patch;
+   yaml_get_version(&major, &minor, &patch);
+
+   h->setKeyValue("major", new QoreBigIntNode(major), 0);
+   h->setKeyValue("minor", new QoreBigIntNode(minor), 0);
+   h->setKeyValue("patch", new QoreBigIntNode(patch), 0);
+
+   return h;
+}
+
 /** @defgroup yaml_emitter_option_constants YAML Emitter Option Constants
  */
 //@{
@@ -59,7 +88,7 @@ const Yaml1_1 = QYE_VER_1_1;
 //@{
 namespace Qore::YAML;
 
-//! Creates a YAML string from Qore data 
+//! Creates a YAML string from Qore data
 /** For information on Qore to YAML serialization, see @ref qore_to_yaml_type_mappings
 
     @param data Qore data to convert; cannot contain any objects or a \c YAML-EMITTER-ERROR exception will be raised
@@ -71,23 +100,35 @@ namespace Qore::YAML;
 
     @par Example:
     @code
-my string $str = makeYAML($data, YAML::Canonical);
+my string $str = make_yaml($data, YAML::Canonical);
     @endcode
 
     @throw YAML-EMITTER-ERROR object found; YAML library error
- */
-string makeYAML(any data, int flags = {Qore::YAML::None}0, softint width = -1, softint indent = 2) [flags=RET_VALUE_ONLY] {
-   QoreYamlStringWriteHandler str;
-   {
-      QoreYamlEmitter emitter(str, flags, width, indent, xsink);
-      if (*xsink)
-	 return 0;
-   
-      if (emitter.emit(data))
-	 return 0;
-   }
 
-   return str.take();
+    @see parse_yaml()
+
+    @since yaml 0.5 as a replacement for deprecated camel-case makeYAML()
+ */
+string make_yaml(any data, int flags = {Qore::YAML::None}0, softint width = -1, softint indent = 2) [flags=RET_VALUE_ONLY] {
+   return q_make_yaml(data, flags, width, indent, xsink);
+}
+
+//! Creates a YAML string from Qore data
+/** For information on Qore to YAML serialization, see @ref qore_to_yaml_type_mappings
+
+    @param data Qore data to convert; cannot contain any objects or a \c YAML-EMITTER-ERROR exception will be raised
+    @param flags binary OR'ed @ref yaml_emitter_option_constants
+    @param width default line width for output, -1 = no line length limit
+    @param indent the number of spaces to use for indentation when outputting block format or multiple lines; note that libyaml seems to be ignoring this parameter for now, so it may not have any effect
+
+    @return the YAML string corresponding to the input
+
+    @throw YAML-EMITTER-ERROR object found; YAML library error
+
+    @deprecated use make_yaml(); camel-case function names were deprecated in yaml 0.5
+ */
+string makeYAML(any data, int flags = {Qore::YAML::None}0, softint width = -1, softint indent = 2) [flags=RET_VALUE_ONLY,DEPRECATED] {
+   return q_make_yaml(data, flags, width, indent, xsink);
 }
 
 //! Parses a YAML string and returns the corresponding Qore value or data structure
@@ -99,12 +140,32 @@ string makeYAML(any data, int flags = {Qore::YAML::None}0, softint width = -1, s
 
     @par Example:
     @code
-my any $data = parseYAML($yaml_string);
+my any $data = parse_yaml($yaml_string);
     @endcode
 
     @throw YAML-PARSER-ERROR error parsing YAML string
+
+    @since yaml 0.5 as a replacement for deprecated camel-case parseYAML()
+
+    @see make_yaml()
  */
-any parseYAML(string yaml) [flags=RET_VALUE_ONLY] {
+any parse_yaml(string yaml) [flags=RET_VALUE_ONLY] {
+   QoreYamlParser parser(*yaml, xsink);
+   return parser.parse();
+}
+
+//! Parses a YAML string and returns the corresponding Qore value or data structure
+/** For information on YAML to Qore deserialization, see @ref qore_to_yaml_type_mappings
+
+    @param yaml The YAML string to deserialize
+
+    @return Qore data as deserialized from the YAML string
+
+    @throw YAML-PARSER-ERROR error parsing YAML string
+
+    @deprecated use parse_yaml(); camel-case function names were deprecated in yaml 0.5
+ */
+any parseYAML(string yaml) [flags=RET_VALUE_ONLY,DEPRECATED] {
    QoreYamlParser parser(*yaml, xsink);
    return parser.parse();
 }
@@ -118,21 +179,25 @@ any parseYAML(string yaml) [flags=RET_VALUE_ONLY] {
 
     @par Example:
     @code
-my hash $hash = getYAMLInfo();
+my hash $hash = get_yaml_info();
     @endcode
+
+    @since yaml 0.5 as a replacement for deprecated camel-case getYAMLInfo()
 */
-hash getYAMLInfo() [flags=CONSTANT] {
-   QoreHashNode *h = new QoreHashNode;
+hash get_yaml_info() [flags=CONSTANT] {
+   return q_get_yaml_info();
+}
 
-   h->setKeyValue("version", new QoreStringNode(yaml_get_version_string()), 0);
+//! Returns version information about libyaml being used by the yaml module
+/** @return a hash with keys as in the following table:
+    - \c version: the version string for the library, ex: \c "0.1.3"
+    - \c major: the integer major version for the library, ex: \c 0
+    - \c minor: the integer minor version for the library, ex: \c 1
+    - \c patch: the integer patch version for the library, ex: \c 3
 
-   int major, minor, patch;
-   yaml_get_version(&major, &minor, &patch);
-
-   h->setKeyValue("major", new QoreBigIntNode(major), 0);
-   h->setKeyValue("minor", new QoreBigIntNode(minor), 0);
-   h->setKeyValue("patch", new QoreBigIntNode(patch), 0);
-
-   return h;
+    @deprecated use get_yaml_info(); camel-case function names were deprecated in yaml 0.5
+*/
+hash getYAMLInfo() [flags=CONSTANT,DEPRECATED] {
+   return q_get_yaml_info();
 }
 //@}

--- a/src/yaml-module.cpp
+++ b/src/yaml-module.cpp
@@ -2,7 +2,7 @@
 /*
   yaml Qore module
 
-  Copyright (C) 2010 - 2014 David Nichols, all rights reserved
+  Copyright (C) 2010 - 2016 David Nichols, all rights reserved
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public

--- a/src/yaml-module.h
+++ b/src/yaml-module.h
@@ -1,10 +1,10 @@
 /* -*- mode: c++; indent-tabs-mode: nil -*- */
 /*
   yaml-module.h
-  
+
   Qore Programming Language
 
-  Copyright 2003 - 2010 David Nichols
+  Copyright 2003 - 2016 David Nichols
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -99,7 +99,7 @@ protected:
    QoreYamlWriteHandler &wh;
 
    bool block,
-      implicit_start_doc, 
+      implicit_start_doc,
       implicit_end_doc;
 
    yaml_version_directive_t *yaml_ver;
@@ -130,7 +130,7 @@ protected:
             return err("error emitting yaml %s %s event", event_str, tag);
          return err("error emitting yaml %s event", event_str);
       }
-            
+
       return 0;
    }
 
@@ -176,7 +176,7 @@ public:
 
    DLLLOCAL int seqStart(yaml_sequence_style_t style = YAML_ANY_SEQUENCE_STYLE,
 			 const char *tag = YAML_SEQ_TAG, const char *anchor = 0, bool implicit = true) {
-      if (!yaml_sequence_start_event_initialize(&event, (yaml_char_t *)anchor, (yaml_char_t *)tag, 
+      if (!yaml_sequence_start_event_initialize(&event, (yaml_char_t *)anchor, (yaml_char_t *)tag,
 						implicit, style))
 	 return err("unknown error initializing yaml sequence start event");
 
@@ -193,7 +193,7 @@ public:
 
    DLLLOCAL int mapStart(yaml_mapping_style_t style = YAML_ANY_MAPPING_STYLE,
 			 const char *tag = YAML_MAP_TAG, const char *anchor = 0, bool implicit = true) {
-      if (!yaml_mapping_start_event_initialize(&event, (yaml_char_t *)anchor, (yaml_char_t *)tag, 
+      if (!yaml_mapping_start_event_initialize(&event, (yaml_char_t *)anchor, (yaml_char_t *)tag,
 					       implicit, style))
 	 return err("unknown error initializing yaml mapping start event");
 
@@ -207,26 +207,26 @@ public:
       return emit("map end");
    }
 
-   DLLLOCAL int emitScalar(const QoreString &value, const char *tag, const char *anchor = 0, 
-		       bool plain_implicit = true, bool quoted_implicit = true, 
+   DLLLOCAL int emitScalar(const QoreString &value, const char *tag, const char *anchor = 0,
+		       bool plain_implicit = true, bool quoted_implicit = true,
 		       yaml_scalar_style_t style = YAML_ANY_SCALAR_STYLE) {
       TempEncodingHelper str(&value, QCS_UTF8, xsink);
       if (*xsink)
 	 return -1;
 
-      if (!yaml_scalar_event_initialize(&event, (yaml_char_t *)anchor, (yaml_char_t *)tag, 
-					(yaml_char_t *)str->getBuffer(), str->strlen(), 
+      if (!yaml_scalar_event_initialize(&event, (yaml_char_t *)anchor, (yaml_char_t *)tag,
+					(yaml_char_t *)str->getBuffer(), str->strlen(),
 					plain_implicit, quoted_implicit, style))
 	 return err("unknown error initializing yaml scalar output event for yaml type '%s', value '%s'", tag, value.getBuffer());
 
       return emit("scalar", tag);
    }
 
-   DLLLOCAL int emitScalar(const char *value, const char *tag, const char *anchor = 0, 
-		       bool plain_implicit = true, bool quoted_implicit = true, 
+   DLLLOCAL int emitScalar(const char *value, const char *tag, const char *anchor = 0,
+		       bool plain_implicit = true, bool quoted_implicit = true,
 		       yaml_scalar_style_t style = YAML_ANY_SCALAR_STYLE) {
-      if (!yaml_scalar_event_initialize(&event, (yaml_char_t *)anchor, (yaml_char_t *)tag, 
-					(yaml_char_t *)value, -1, 
+      if (!yaml_scalar_event_initialize(&event, (yaml_char_t *)anchor, (yaml_char_t *)tag,
+					(yaml_char_t *)value, -1,
 					plain_implicit, quoted_implicit, style)) {
 	 return err("unknown error initializing yaml scalar output event for yaml type '%s', value '%s'", tag, value);
       }
@@ -234,25 +234,25 @@ public:
       return emit("scalar", tag);
    }
 
-   DLLLOCAL int emit(const QoreString &str) {
+   DLLLOCAL int emitValue(const QoreString &str) {
       TempEncodingHelper tmp(&str, QCS_UTF8, xsink);
       if (!tmp)
 	 return -1;
       return emitScalar(**tmp, YAML_STR_TAG, 0, true, true, YAML_DOUBLE_QUOTED_SCALAR_STYLE);
    }
-   
-   DLLLOCAL int emit(const QoreBigIntNode &bi) {
+
+   DLLLOCAL int emitValue(int64 i) {
       QoreString tmp;
-      tmp.sprintf("%lld", bi.val);
+      tmp.sprintf("%lld", i);
       return emitScalar(tmp, YAML_INT_TAG);
    }
 
-   DLLLOCAL int emit(const QoreFloatNode &f) {
+   DLLLOCAL int emitValue(double f) {
       QoreString tmp;
-      if (((double)((int64)f.f)) == f.f)
-         tmp.sprintf("%g.0", f.f);
+      if (((double)((int64)f)) == f)
+         tmp.sprintf("%g.0", f);
       else
-         tmp.sprintf("%.25g", f.f);
+         tmp.sprintf("%.25g", f);
 
       if (tmp == "inf")
          tmp.set("@inf@");
@@ -265,10 +265,8 @@ public:
       return emitScalar(tmp, YAML_FLOAT_TAG);
    }
 
-#ifdef _QORE_HAS_NUMBER_TYPE
-   DLLLOCAL int emit(const QoreNumberNode& n) {
+   DLLLOCAL int emitValue(const QoreNumberNode& n) {
       QoreString tmp;
-#ifdef _QORE_HAS_NUMBER_CONS_WITH_PREC
       n.toString(tmp, QORE_NF_SCIENTIFIC|QORE_NF_RAW);
       if (tmp == "inf")
          tmp.set("@inf@n");
@@ -280,22 +278,17 @@ public:
          tmp.concat('n');
       // append precision
       tmp.sprintf("{%d}", n.getPrec());
-#else
-      n.getStringRepresentation(tmp);
-      tmp.concat('n');
-#endif
       //printd(5, "yaml emit number: %s\n", tmp.getBuffer());
       return emitScalar(tmp, QORE_YAML_NUMBER_TAG);
    }
-#endif
 
-   DLLLOCAL int emit(const QoreBoolNode& b) {
+   DLLLOCAL int emitValue(bool b) {
       QoreString tmp;
-      tmp.sprintf("%s", b.getValue() ? "true" : "false");
+      tmp.sprintf("%s", b ? "true" : "false");
       return emitScalar(tmp, YAML_BOOL_TAG);
    }
 
-   DLLLOCAL int emit(const QoreListNode &l) {
+   DLLLOCAL int emitValue(const QoreListNode &l) {
       if (seqStart(block ? YAML_BLOCK_SEQUENCE_STYLE : YAML_FLOW_SEQUENCE_STYLE))
 	 return -1;
       ConstListIterator li(l);
@@ -306,7 +299,7 @@ public:
       return seqEnd();
    }
 
-   DLLLOCAL int emit(const QoreHashNode &h) {
+   DLLLOCAL int emitValue(const QoreHashNode &h) {
       if (mapStart(block ? YAML_BLOCK_MAPPING_STYLE : YAML_FLOW_MAPPING_STYLE))
 	 return -1;
       ConstHashIterator hi(h);
@@ -319,20 +312,20 @@ public:
       return mapEnd();
    }
 
-   DLLLOCAL int emit(const DateTime &d);
+   DLLLOCAL int emitValue(const DateTime &d);
 
-   DLLLOCAL int emit(const BinaryNode &b) {
+   DLLLOCAL int emitValue(const BinaryNode &b) {
       QoreString str(QCS_UTF8);
       str.concatBase64(&b);
       return emitScalar(str, YAML_BINARY_TAG, 0, false, false, YAML_DOUBLE_QUOTED_SCALAR_STYLE);
    }
 
-   DLLLOCAL int emit(const AbstractQoreNode *p);
-   
+   DLLLOCAL int emit(const QoreValue& v);
+
    DLLLOCAL int emitNull() {
       return emitScalar(NullStr, YAML_NULL_TAG);
    }
-   
+
    DLLLOCAL void setCanonical(bool b = true) {
       yaml_emitter_set_canonical(&emitter, b);
    }
@@ -340,7 +333,7 @@ public:
    DLLLOCAL void setUnicode(bool b = true) {
       yaml_emitter_set_unicode(&emitter, b);
    }
-   
+
    DLLLOCAL bool getBlock() const {
       return block;
    }
@@ -383,7 +376,7 @@ protected:
 
    DLLLOCAL int getEvent() {
       discardEvent();
-	 
+
       if (!yaml_parser_parse(&parser, &event)) {
 	 valid = false;
       xsink->raiseException(QY_PARSE_ERR, "getEvent: unexpected event '%s' when parsing YAML document", get_event_name(event.type));
@@ -429,7 +422,7 @@ public:
 
    DLLLOCAL ~QoreYamlParser() {
       discardEvent();
-      yaml_parser_delete(&parser); 
+      yaml_parser_delete(&parser);
    }
 };
 

--- a/test/yaml.qtest
+++ b/test/yaml.qtest
@@ -1,15 +1,18 @@
 #!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
+
 %new-style
-%requires yaml
 %require-types
-%requires qore >= 0.8.12
+%strict-args
+%enable-all-warnings
+
+%requires yaml
 %requires QUnit
+
 %exec-class Main
 
-
 const DATA = (
-        1, "two", 
+        1, "two",
         NOTHING,
         0,
         0.0,
@@ -28,7 +31,7 @@ const DATA = (
         P2M3DT10H14u,
         now_us(),
         binary("hello, how's it going, this is a long string, you know XXXXXXXXXXXXXXXXXXXXXXXX"),
-        ("a" : 2.0, 
+        ("a" : 2.0,
          "b" : "hello",
          "key" : True),
         @nan@n,
@@ -59,32 +62,32 @@ public class Main inherits QUnit::Test {
     }
 
     testYaml() {
-        string s = makeYAML(DATA);
-        any l = parseYAML(s);
+        string s = make_yaml(DATA);
+        any l = parse_yaml(s);
         testAssertion("test simple yaml", \equals(), (DATA, l));
     }
 
     testOptions() {
         ListIterator it(YAML_OPTIONS);
         while (it.next()) {
-            string s = makeYAML(DATA, it.getValue());
-            any l = parseYAML(s);
-            testAssertion(sprintf("option: %n", it.getValue()), \equals(), (DATA, l));
+            string s = make_yaml(DATA, it.getValue());
+            any l = parse_yaml(s);
+            assertEq(DATA, l, sprintf("option: %y", it.getValue()));
         }
     }
 
     testIndent() {
         for (int i = 0; i < 100; i++) {
-            string s = makeYAML(DATA, NOTHING, NOTHING, 1);
-            any l = parseYAML(s);
+            string s = make_yaml(DATA, NOTHING, NOTHING, 1);
+            any l = parse_yaml(s);
             testAssertion(sprintf("indent: %2d", i), \equals(), (DATA, l));
         }
     }
 
     testLen() {
         for (int i = -10; i < 11; i++) {
-            string s = makeYAML(DATA, NOTHING, i);
-            any l = parseYAML(s);
+            string s = make_yaml(DATA, NOTHING, i);
+            any l = parse_yaml(s);
             testAssertion(sprintf("len: %2d", i), \equals(), (DATA, l));
         }
     }
@@ -95,8 +98,7 @@ public class Main inherits QUnit::Test {
         date dt2 = tz.date(dt1);
         testAssertion("timezone test", \equals(), (dt1, dt2));
 
-        any dt3 = parseYAML(makeYAML(dt1));
+        any dt3 = parse_yaml(make_yaml(dt1));
         testAssertion("yaml date test", \equals(), (dt2, dt3));
     }
 }
-


### PR DESCRIPTION
…ons confirming to the standard function naming convention, ported to QValue API

refs #354 fixed parsing arbitrary-precision numeric values in canonically-serialized YAML strings
refs #355 fixed parsing +/-inf floating-point values in canonically-serialized YAML strings

all tests are now passing, verified with valgrind
